### PR TITLE
Reduce the model size; fix a bug; reproduce the 4-node counterexample.

### DIFF
--- a/MongoReplReconfig.tla
+++ b/MongoReplReconfig.tla
@@ -264,7 +264,7 @@ SendConfig(i, j) ==
     \* action to propagate terms, though, even if the config is not updated.
     /\ config' = [config EXCEPT ![j] = IF IsNewerConfig(i, j) THEN config[i] ELSE config[j]]
     /\ configVersion' = [configVersion EXCEPT ![j] = IF IsNewerConfig(i, j) THEN configVersion[i] ELSE configVersion[j]]
-    /\ configTerm' = [configTerm EXCEPT ![j] = configTerm[i]]
+    /\ configTerm' = [configTerm EXCEPT ![j] = IF IsNewerConfig(i, j) THEN configTerm[i] ELSE configTerm[j]]
     \* Update terms of sender and receiver i.e. to simulate an RPC request and response (heartbeat).
     /\ currentTerm' = [currentTerm EXCEPT ![i] = Max({currentTerm[i], currentTerm[j]}),
                                           ![j] = Max({currentTerm[i], currentTerm[j]})]

--- a/MongoReplReconfig.tla
+++ b/MongoReplReconfig.tla
@@ -248,7 +248,8 @@ Reconfig(i) ==
         \* Record the term of the primary that wrote this config.
         /\ configTerm' = [configTerm EXCEPT ![i] = currentTerm[i]]
         /\ \* Pick a config version higher than all existing config versions.
-            LET newConfigVersion == configVersion[i] + 1 IN
+            \* Unique config version implies cv1.version > cv2.version => cv1.term > cv2.term
+            LET newConfigVersion == Max(Range(configVersion)) + 1 IN
             configVersion' = [configVersion EXCEPT ![i] = newConfigVersion]
         /\ UNCHANGED <<serverVars, log, immediatelyCommitted>>
 

--- a/MongoReplReconfig.tla
+++ b/MongoReplReconfig.tla
@@ -379,9 +379,16 @@ IsPrefix(xlog, ylog) ==
 (**************************************************************************************************)
 (* There should be at most one leader per term.                                                   *)
 (**************************************************************************************************)
-ElectionSafety == \A e1, e2 \in elections: 
-                    e1.eterm = e2.eterm => e1.eleader = e2.eleader
-       
+TwoPrimariesInSameTerm ==
+    \E i, j \in Server :
+        /\ i # j
+        /\ currentTerm[i] = currentTerm[j]
+        /\ state[i] = Primary
+        /\ state[j] = Primary
+
+NoTwoPrimariesInSameTerm == ~TwoPrimariesInSameTerm
+ElectionSafety == NoTwoPrimariesInSameTerm
+
 (**************************************************************************************************)
 (* Only uncommitted entries are allowed to be deleted from logs.                                  *)
 (**************************************************************************************************)

--- a/MongoReplReconfig.tla
+++ b/MongoReplReconfig.tla
@@ -70,6 +70,9 @@ vars == <<serverVars, log, immediatelyCommitted, config, configVersion, configTe
 \* The set of all quorums. This just calculates simple majorities, but the only
 \* important property is that every quorum overlaps with every other.
 Quorum == {i \in SUBSET(Server) : Cardinality(i) * 2 > Cardinality(Server)}
+MajorityOnlyQuorums(S) == {i \in SUBSET(S) :
+    /\ Cardinality(i) * 2 > Cardinality(S)
+    /\ Cardinality(i) * 2 <= Cardinality(S) + 2}
 Quorums(S) == {i \in SUBSET(S) : Cardinality(i) * 2 > Cardinality(S)}
     
 \* Return the minimum value from a set, or undefined if the set is empty.
@@ -380,7 +383,8 @@ ElectableNodeExists == \E s \in Server : ENABLED BecomeLeader(s)
 (**************************************************************************************************)
 (* Spec definition                                                                                *)
 (**************************************************************************************************)
- 
+InitConfigConstriant(c) == TRUE
+InitConfigMaxSizeOnly(c) == c = Server
 Init == 
     \* Server variables.
     /\ currentTerm = [i \in Server |-> 0]
@@ -393,6 +397,7 @@ Init ==
     \* We allow an initial config to be any non-empty subset of the current servers.
     /\ \E initConfig \in (SUBSET Server) : 
         /\ initConfig # {}
+        /\ InitConfigConstriant(initConfig)
         /\ config = [i \in Server |-> initConfig]
     /\ configVersion =  [i \in Server |-> 0]
     /\ configTerm    =  [i \in Server |-> 0]

--- a/MongoReplReconfig.tla
+++ b/MongoReplReconfig.tla
@@ -260,9 +260,10 @@ SendConfig(i, j) ==
     \* TODO: Only allow configs to propagate from a primary to a secondary.
     \* Only update config if the received config version is newer. We still allow this
     \* action to propagate terms, though, even if the config is not updated.
-    /\ config' = [config EXCEPT ![j] = IF IsNewerConfig(i, j) THEN config[i] ELSE config[j]]
-    /\ configVersion' = [configVersion EXCEPT ![j] = IF IsNewerConfig(i, j) THEN configVersion[i] ELSE configVersion[j]]
-    /\ configTerm' = [configTerm EXCEPT ![j] = IF IsNewerConfig(i, j) THEN configTerm[i] ELSE configTerm[j]]
+    /\ IsNewerConfig(i, j)
+    /\ config' = [config EXCEPT ![j] = config[i]]
+    /\ configVersion' = [configVersion EXCEPT ![j] = configVersion[i]]
+    /\ configTerm' = [configTerm EXCEPT ![j] = configTerm[i]]
     \* Update terms of sender and receiver i.e. to simulate an RPC request and response (heartbeat).
     /\ currentTerm' = [currentTerm EXCEPT ![i] = Max({currentTerm[i], currentTerm[j]}),
                                           ![j] = Max({currentTerm[i], currentTerm[j]})]

--- a/MongoReplReconfig.tla
+++ b/MongoReplReconfig.tla
@@ -244,7 +244,7 @@ Reconfig(i) ==
         \* Record the term of the primary that wrote this config.
         /\ configTerm' = [configTerm EXCEPT ![i] = currentTerm[i]]
         /\ \* Pick a config version higher than all existing config versions.
-            LET newConfigVersion == Max(Range(configVersion)) + 1 IN
+            LET newConfigVersion == configVersion[i] + 1 IN
             configVersion' = [configVersion EXCEPT ![i] = newConfigVersion]
         /\ UNCHANGED <<serverVars, log, immediatelyCommitted>>
 

--- a/MongoReplReconfig.tla
+++ b/MongoReplReconfig.tla
@@ -407,6 +407,7 @@ ConfigEventuallyPropagates ==
                            \/ state[i] = Down
                            \/ configVersion[i] = configVersion[j]
 
+ElectableNodeEventuallyExists == <>(\E s \in Server : state[s] = Primary)
 -------------------------------------------------------------------------------------------
 
 (**************************************************************************************************)

--- a/MongoReplReconfig.tla
+++ b/MongoReplReconfig.tla
@@ -209,22 +209,20 @@ BecomeLeader(i) ==
 
 
 \* A quorum of nodes have received this config or a newer one.
-ConfigQuorumCheck(i) == 
-    \E quorum \in Quorums(config[i]) : \A s \in quorum : configVersion[s] >= configVersion[i]
+ConfigQuorumCheck(self, s) == configVersion[self] <= configVersion[s]
 
 \* Was an op was committed in the config of node i.
 OpCommittedInConfig(i) ==
     /\ \E e \in immediatelyCommitted : e[3] = configVersion[i]
 
 \* Did a node talked to a quorum as primary.
-TermQuorumCheck(i) ==
-    /\ \A q \in Quorums(config[i]) :
-       \A s \in q : currentTerm[i] >= currentTerm[s]
+TermQuorumCheck(self, s) == currentTerm[self] >= currentTerm[s]
 
 \* Is the config on node i currently "safe".
 ConfigIsSafe(i) ==
-    /\ TermQuorumCheck(i)
-    /\ ConfigQuorumCheck(i)
+    /\ \E q \in Quorums(config[i]):
+       \A s \in q : /\ TermQuorumCheck(i, s)
+                    /\ ConfigQuorumCheck(i, s)
     /\ OpCommittedInConfig(i)
 
 \*

--- a/models/election_safety/MC_6_term_config_check_4_nodes.cfg
+++ b/models/election_safety/MC_6_term_config_check_4_nodes.cfg
@@ -4,14 +4,12 @@ CONSTANT Nil = Nil
 CONSTANTS
 Secondary = Secondary
 Primary = Primary
-Candidate = Candidate
+Down = Down
 CONSTANTS
 MaxLogLen = 0
 MaxTerm = 3
 MaxConfigVersion = 3
 CONSTANT OpCommittedInConfig <- TRUE
-\* CONSTANT Quorums <- MajorityOnlyQuorums
-\* CONSTANT IsNewerConfig <- TRUE
 SYMMETRY ServerSymmetry
 CONSTRAINT StateConstraint
 INVARIANT ElectionSafety

--- a/models/election_safety/MC_6_term_config_check_4_nodes.cfg
+++ b/models/election_safety/MC_6_term_config_check_4_nodes.cfg
@@ -16,3 +16,4 @@ INVARIANT ElectionSafety
 \* INVARIANT TestInvariant
 PROPERTY ConfigEventuallyPropagates
 INVARIANT ConfigVersionIncreasesWithTerm
+PROPERTY ElectableNodeEventuallyExists

--- a/models/election_safety/MC_6_term_config_check_4_nodes.cfg
+++ b/models/election_safety/MC_6_term_config_check_4_nodes.cfg
@@ -1,0 +1,19 @@
+SPECIFICATION Spec
+CONSTANT Server = {n1, n2, n3, n4}
+CONSTANT Nil = Nil
+CONSTANTS
+Secondary = Secondary
+Primary = Primary
+Candidate = Candidate
+CONSTANTS
+MaxLogLen = 0
+MaxTerm = 3
+MaxConfigVersion = 3
+CONSTANT OpCommittedInConfig <- TRUE
+\* CONSTANT Quorums <- MajorityOnlyQuorums
+CONSTANT InitConfigConstriant <- InitConfigMaxSizeOnly
+CONSTANT IsNewerConfig <- TRUE
+SYMMETRY ServerSymmetry
+CONSTRAINT StateConstraint
+INVARIANT ElectionSafety
+\* INVARIANT TestInvariant

--- a/models/election_safety/MC_6_term_config_check_4_nodes.cfg
+++ b/models/election_safety/MC_6_term_config_check_4_nodes.cfg
@@ -11,9 +11,10 @@ MaxTerm = 3
 MaxConfigVersion = 3
 CONSTANT OpCommittedInConfig <- TRUE
 \* CONSTANT Quorums <- MajorityOnlyQuorums
-CONSTANT InitConfigConstriant <- InitConfigMaxSizeOnly
-CONSTANT IsNewerConfig <- TRUE
+\* CONSTANT IsNewerConfig <- TRUE
 SYMMETRY ServerSymmetry
 CONSTRAINT StateConstraint
 INVARIANT ElectionSafety
 \* INVARIANT TestInvariant
+PROPERTY ConfigEventuallyPropagates
+INVARIANT ConfigVersionIncreasesWithTerm


### PR DESCRIPTION
As mentioned in the last commit's comment, using `MC_6_term_config_check_4_nodes.cfg` can reproduce the diverged configs problem in seconds.