### PR TITLE
Simplify liveness property.

### DIFF
--- a/MC.cfg
+++ b/MC.cfg
@@ -18,7 +18,7 @@ SYMMETRY ServerSymmetry
 CONSTRAINT StateConstraint
 INVARIANT ElectionSafety
 \* INVARIANT InstalledConfigsOverlap
-INVARIANT ActiveConfigsOverlap
+INVARIANT AtMostOneActiveConfig
 \* INVARIANT ConfigsOverlap
 \* PROPERTY NeverRollbackCommitted
 \* PROPERTY ElectableNodeExists

--- a/MongoReplReconfig.tla
+++ b/MongoReplReconfig.tla
@@ -119,14 +119,6 @@ CanRollback(i, j) ==
        \/ /\ Len(log[i]) <= Len(log[j])
           /\ LastTerm(log[i]) /= LogTerm(j, Len(log[i]))
 
-\* Returns the highest common index between two divergent logs, 'li' and 'lj'.
-\* If there is no common index between the logs, returns 0.
-RollbackCommonPoint(li, lj) ==
-    LET commonIndices == {k \in DOMAIN li :
-                            /\ k <= Len(lj)
-                            /\ li[k] = lj[k]} IN
-        IF commonIndices = {} THEN 0 ELSE Max(commonIndices)
-
 \* Is the config of node i considered 'newer' than the config of node j. This is the condition for
 \* node j to accept the config of node i.
 IsNewerConfig(i, j) ==

--- a/MongoReplReconfig.tla
+++ b/MongoReplReconfig.tla
@@ -410,13 +410,20 @@ ActiveConfigsOverlap == \A x,y \in InstalledConfigs : ActiveConfig(x) /\ ActiveC
 (**************************************************************************************************)
 (* Liveness properties                                                                            *)
 (**************************************************************************************************)
-ConfigEventuallyPropagates ==
-    \A i, j \in Server:
-        i \in config[j] ~> \/ i \notin config[j]
-                           \/ state[i] = Down
-                           \/ configVersion[i] = configVersion[j]
+AnyNodeCanRollBack == \E s \in Server :
+    \E syncSource \in Server: ENABLED RollbackEntries(syncSource, s)
 
-ElectableNodeEventuallyExists == <>(\E s \in Server : state[s] = Primary)
+ConfigEventuallyPropagates == <>(
+    \/ AnyNodeCanRollBack
+    \/ \A i, j \in Server:
+          \/ i \notin config[j]
+          \/ state[i] = Down
+          \/ configVersion[i] = configVersion[j]
+)
+
+ElectableNodeEventuallyExists == <>(
+    \/ AnyNodeCanRollBack
+    \/ \E s \in Server : state[s] = Primary)
 
 (**************************************************************************************************)
 (* Spec definition                                                                                *)

--- a/MongoReplReconfig.tla
+++ b/MongoReplReconfig.tla
@@ -272,6 +272,7 @@ Reconfig(i) ==
         /\ \/ \E n \in newConfig : newConfig \ {n} = config[i]  \* add 1.
            \/ \E n \in config[i] : config[i] \ {n} = newConfig  \* remove 1.
         /\ i \in newConfig
+        \* Require that at least a quorum of nodes in the new config are not down.
         /\ AliveNodes(newConfig) \in Quorums(newConfig)
         \* The config on this node takes effect immediately
         /\ config' = [config EXCEPT ![i] = newConfig]

--- a/MongoReplReconfig.tla
+++ b/MongoReplReconfig.tla
@@ -398,14 +398,20 @@ InstalledConfigs == Range(config)
 \* Do all quorums of set x and set y share at least one overlapping node.
 QuorumsOverlap(x, y) == \A qx \in Quorums(x), qy \in Quorums(y) : qx \cap qy # {}
 
-\* Is a given config "active"
+\* Is a given config "active" i.e. can it form a quorum.
 ActiveConfig(cfg) == \E Q \in Quorums(cfg) : \A s \in Q : config[s] = cfg
+
+\* The set of all active configs.
+ActiveConfigs == {c \in InstalledConfigs : ActiveConfig(c)}
 
 \* For all installed configs, do their quorums overlap.
 InstalledConfigsOverlap == \A x,y \in InstalledConfigs : QuorumsOverlap(x, y)
 
 \* For all active configs, do their quorums overlap.
-ActiveConfigsOverlap == \A x,y \in InstalledConfigs : ActiveConfig(x) /\ ActiveConfig(y) => QuorumsOverlap(x, y)
+ActiveConfigsOverlap == \A x,y \in ActiveConfigs : QuorumsOverlap(x, y)
+
+\* Property asserting that there is never more than 1 active config at a time.
+AtMostOneActiveConfig == Cardinality(ActiveConfigs) <= 1
 
 (**************************************************************************************************)
 (* Liveness properties                                                                            *)
@@ -452,7 +458,7 @@ BecomeLeaderAction      ==  \E s \in AliveNodes(Server) : BecomeLeader(s)
 ClientRequestAction     ==  \E s \in AliveNodes(Server) : ClientRequest(s)
 GetEntriesAction        ==  \E s, t \in AliveNodes(Server) : GetEntries(s, t)
 RollbackEntriesAction   ==  \E s, t \in AliveNodes(Server) : RollbackEntries(s, t)
-ReconfigAction          ==  \E s \in AliveNodes(Server) : Reconfig(s)
+ReconfigAction          ==  \E s \in AliveNodes(Server) : Reconfig(s) \*/\ PrintT(Cardinality(ActiveConfigs))
 SendConfigAction        ==  \E s,t \in AliveNodes(Server) : SendConfig(s, t)
 CommitEntryAction       ==  \E s \in AliveNodes(Server) : CommitEntry(s)
 ShutDownAction          ==  \E s \in AliveNodes(Server) : ShutDown(s)

--- a/MongoReplReconfig.tla
+++ b/MongoReplReconfig.tla
@@ -413,7 +413,7 @@ AtMostOneActiveConfig == Cardinality(ActiveConfigs) <= 1
 AnyNodeCanRollBack == \E s \in Server :
     \E syncSource \in Server: ENABLED RollbackEntries(syncSource, s)
 
-ConfigEventuallyPropagates == <>(
+ConfigEventuallyPropagates == []<>(
     \/ AnyNodeCanRollBack
     \/ \A i, j \in Server:
           \/ i \notin config[j]
@@ -421,7 +421,7 @@ ConfigEventuallyPropagates == <>(
           \/ configVersion[i] = configVersion[j]
 )
 
-ElectableNodeEventuallyExists == <>(
+ElectableNodeEventuallyExists == []<>(
     \/ AnyNodeCanRollBack
     \/ \E s \in Server : state[s] = Primary)
 

--- a/MongoReplReconfig.tla
+++ b/MongoReplReconfig.tla
@@ -285,10 +285,9 @@ Reconfig(i) ==
         /\ UNCHANGED <<serverVars, log, immediatelyCommitted>>
 
 \* [ACTION]
-\* Node i sends its current config to node j. It is only accepted if the config version is newer.
+\* Node i sends its current config to node j. It is only accepted if the config is newer.
 SendConfig(i, j) ==
-    \* Only update config if the received config version is newer. We still allow this
-    \* action to propagate terms, though, even if the config is not updated.
+    \* Only update config if the received config is newer and its term is >= than your current term.
     /\ IsNewerConfig(i, j)
     /\ configTerm[i] >= currentTerm[j]
     /\ config' = [config EXCEPT ![j] = config[i]]

--- a/model_checking.md
+++ b/model_checking.md
@@ -87,3 +87,22 @@ Ran a 5 node model on this [revision](https://github.com/will62794/mongo-repl-re
 - Total states generated: 520,720,228
 - Distinct states found: 13,935,343
 - Max throughput: 4,647,994 s/min
+
+### Nov. 21, 2019
+
+Ran a 3 node model with logs to check NeverRollbackCommitted after I [updated the definition](https://github.com/will62794/mongo-repl-reconfig/commit/8a2f5dde4053d1db6a432a2989c99c3f6a8fe45f) of CanRollback.
+
+- [Spec Revision](https://github.com/will62794/mongo-repl-reconfig/tree/8a2f5dde4053d1db6a432a2989c99c3f6a8fe45f) 
+- Reporter: Will Schultz
+- Invariants: `NeverRollbackCommitted`
+- Server = {n1, n2, n3}
+- MaxLogLen = 2
+- MaxTerm = 3
+- MaxConfigVersion = 3
+- Symmetry: `ServerSymmetry`
+- 11 TLC workers on Ubuntu 16.10 workstation.
+- Error: No violation found.
+- Model checking time: 03min 25s
+- Total states generated: 49,875,644
+- Distinct states found: 3,008,553
+- Max throughput: 13,501,997 s/min

--- a/model_checking.md
+++ b/model_checking.md
@@ -106,3 +106,24 @@ Ran a 3 node model with logs to check NeverRollbackCommitted after I [updated th
 - Total states generated: 49,875,644
 - Distinct states found: 3,008,553
 - Max throughput: 13,501,997 s/min
+
+### Nov. 22, 2019
+
+- [Spec Revision](https://github.com/will62794/mongo-repl-reconfig/tree/136f130876fff112090ef1243de2f80137117fbe) 
+- Reporter: Will Schultz
+- Invariants: `NeverRollbackCommitted`
+- Server = {n1, n2, n3, n4}
+- MaxLogLen = 2
+- MaxTerm = 3
+- MaxConfigVersion = 3
+- Symmetry: `ServerSymmetry`
+- 36 TLC workers on c5d.24xlarge EC2 instance (96 cores, 192GB memory)
+- Error: No violation found.
+- Model checking time: 08h 38min
+- Total states generated: 11,025,885,594
+- Distinct states found: 414,201,087
+- Max throughput: 24,547,077 s/min
+
+```
+Running breadth-first search Model-Checking with fp 14 and seed -5659610528572021697 with 36 workers on 96 cores with 106832MB heap and 120000MB offheap memory [pid: 78293] (Linux 4.15.0-1051-aws amd64Ubuntu 11.0.4 x86_64, OffHeapDiskFPSet, DiskStateQueue).
+```

--- a/model_checking.md
+++ b/model_checking.md
@@ -70,3 +70,20 @@ To do a sanity check, I checked a model on the latest [revision](https://github.
 
 I tried to resolve the problem mentioned above with `AliveNodes` by f[ixing its definition](https://github.com/will62794/mongo-repl-reconfig/commit/75c4407258ef63b982ac5ea45c120330b19125df). I can now confirm that with the fixed definition, removing the `ConfigIsSafe` definition entirely on a 3 node model will cause the model checker to quickly find a violation. Running the spec on this [revision](https://github.com/will62794/mongo-repl-reconfig/blob/75c4407258ef63b982ac5ea45c120330b19125df/MongoReplReconfig.tla), the model checker finds an ElectionSafety violation in under a second with a 3 node model with no logs. This seems to confirm that the definition of `AliveNodes` was causing the problem. I will run larger models with the fixed definition to make sure it wasn't masking any bugs.
 
+### Nov. 20, 2019
+
+Ran a 5 node model on this [revision](https://github.com/will62794/mongo-repl-reconfig/tree/c66da514c1eac158d46b6becb7d18f643ca7538f) after fixing the definition of `AliveNodes`. TLC reported no violation of ElectionSafety.
+
+- Reporter: Will Schultz
+- Invariants: `ElectionSafety`
+- Server = {n1, n2, n3, n4, n5}
+- MaxLogLen = 0
+- MaxTerm = 3
+- MaxConfigVersion = 3
+- Symmetry: `ServerSymmetry`
+- 11 TLC workers on Ubuntu 16.10 workstation.
+- Error: No violation found.
+- Model checking time: 02h 06min
+- Total states generated: 520,720,228
+- Distinct states found: 13,935,343
+- Max throughput: 4,647,994 s/min

--- a/model_checking.md
+++ b/model_checking.md
@@ -127,3 +127,23 @@ Ran a 3 node model with logs to check NeverRollbackCommitted after I [updated th
 ```
 Running breadth-first search Model-Checking with fp 14 and seed -5659610528572021697 with 36 workers on 96 cores with 106832MB heap and 120000MB offheap memory [pid: 78293] (Linux 4.15.0-1051-aws amd64Ubuntu 11.0.4 x86_64, OffHeapDiskFPSet, DiskStateQueue).
 ```
+
+### Nov. 22, 2019
+
+Ran a model with the `ShutDown` action completely disabled, to see if it reduces the state space for safety checking.
+
+- [Spec Revision](https://github.com/will62794/mongo-repl-reconfig/tree/136f130876fff112090ef1243de2f80137117fbe) 
+- Reporter: Will Schultz
+- Invariants: `NeverRollbackCommitted`
+- Server = {n1, n2, n3, n4}
+- MaxLogLen = 2
+- MaxTerm = 3
+- MaxConfigVersion = 3
+- Symmetry: `ServerSymmetry`
+- 36 TLC workers on c5d.24xlarge EC2 instance (96 cores, 192GB memory)
+- Error: No violation found.
+- Model checking time: 05h 20min
+- Total states generated: 7,661,579,353
+- Distinct states found: 246,830,557
+- Max throughput: 29,460,611 s/min
+

--- a/models/never_rollback_committed/MC_6_all_checks_3_nodes.cfg
+++ b/models/never_rollback_committed/MC_6_all_checks_3_nodes.cfg
@@ -1,0 +1,14 @@
+SPECIFICATION Spec
+CONSTANT Server = {n1, n2, n3, n4}
+CONSTANT Nil = Nil
+CONSTANTS 
+Secondary = Secondary
+Primary = Primary
+Down = Down
+CONSTANTS
+MaxLogLen = 2
+MaxTerm = 3
+MaxConfigVersion = 3
+SYMMETRY ServerSymmetry
+CONSTRAINT StateConstraint
+PROPERTY  NeverRollbackCommitted

--- a/models/never_rollback_committed/MC_6_all_checks_3_nodes.cfg
+++ b/models/never_rollback_committed/MC_6_all_checks_3_nodes.cfg
@@ -1,5 +1,5 @@
 SPECIFICATION Spec
-CONSTANT Server = {n1, n2, n3, n4}
+CONSTANT Server = {n1, n2, n3}
 CONSTANT Nil = Nil
 CONSTANTS 
 Secondary = Secondary

--- a/models/never_rollback_committed/MC_6_all_checks_4_nodes.cfg
+++ b/models/never_rollback_committed/MC_6_all_checks_4_nodes.cfg
@@ -1,0 +1,14 @@
+SPECIFICATION Spec
+CONSTANT Server = {n1, n2, n3, n4}
+CONSTANT Nil = Nil
+CONSTANTS 
+Secondary = Secondary
+Primary = Primary
+Down = Down
+CONSTANTS
+MaxLogLen = 2
+MaxTerm = 3
+MaxConfigVersion = 3
+SYMMETRY ServerSymmetry
+CONSTRAINT StateConstraint
+PROPERTY  NeverRollbackCommitted

--- a/models/never_rollback_committed/MC_6_all_checks_5_nodes.cfg
+++ b/models/never_rollback_committed/MC_6_all_checks_5_nodes.cfg
@@ -1,0 +1,14 @@
+SPECIFICATION Spec
+CONSTANT Server = {n1, n2, n3, n4, n5}
+CONSTANT Nil = Nil
+CONSTANTS 
+Secondary = Secondary
+Primary = Primary
+Down = Down
+CONSTANTS
+MaxLogLen = 2
+MaxTerm = 3
+MaxConfigVersion = 3
+SYMMETRY ServerSymmetry
+CONSTRAINT StateConstraint
+PROPERTY  NeverRollbackCommitted


### PR DESCRIPTION
I found this makes TLC run faster. Before: `317,082 s/min`. After: `1,794,666 s/min`.